### PR TITLE
Listener checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .DS_Store
 **/.DS_Store
+lastfm_delete_button.pem

--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
-Very simple chrome extension for Last.FM. Using the plainest JS I can in case there are issues with modern JS support.
+To install, drag and drop the CRX file into a window with [chrome://extensions/] open. It's possible I may forget to update the CRX file on some updates so double check that it was updated in the most recent commit.
 
-The delete scrobble button was moved in the redesign last year to be under a drop down menu. As the system frequently will record things as being played which weren't, this is pretty awkward for tidying up records. This extension scrapes the button and its respective form from the drop down menu and plants it roughly in the same location it used to be.
+## Problem
+The delete scrobble button was moved in the redesign last year to be under a drop down menu. As the system frequently will record things as being played which weren't, this is pretty awkward for tidying up records.
+
+## Solution
+An extension which scrapes the button and its respective form from the drop down menu and plants it roughly in the same location it used to be.
+
+## Implementation
+A very simple chrome extension for Last.FM. Using the plainest JS I can in case there are issues with modern JS support.
+This whole extension depends on the DOM being as it currently is, even minor changes on their end could disrupt functionality.
 
 The code currently runs on every last.fm library page which may have deletion options (URLs specified in the manifest) and only makes changes on pages which do have them.
 
-As URL changes don't cause whole page resets, the extension required a hard refresh on each new page after the first one. The current setup uses a pretty simplistic series of loops and listeners to deal with this. If the extension isn't running correctly for you, the most likely cause is that some of the timeouts aren't optimal for your network.
+### Issues
+As URL changes don't cause whole page resets, the extension required a hard refresh on each new page after the first one. The current setup uses a pretty simplistic series of loops, checks and listeners to deal with this.
 
-
-Things to do:
+## To do
 - Add a user input of some kind to ensure it only checks on pages with your username
 - Improve listener implementation
+- Switch to more advanced extension optimisations (probably not worth the effort)
 

--- a/delete-code.js
+++ b/delete-code.js
@@ -1,3 +1,7 @@
+// The DOM element we're focusing on
+var scrobblelist = document.getElementsByClassName('tracklist-section')[0];
+
+// pulls existing form for deleting associated scrobble from dropdown menu
 var get_delete_form = function(scrobble_row){
   var drop_down_forms = scrobble_row
     .getElementsByClassName('chartlist-more-menu')[0]
@@ -15,9 +19,9 @@ var get_delete_form = function(scrobble_row){
   return null;
 }
 
+// plugs a duplicate of the pulled form into the table
 var insert_delete_forms = function(){
   var scrobbles = document.getElementsByClassName('js-link-block js-focus-controls-container');
-  console.log('last.fm delete button script is running');
 
   for(var i_scrob = 0; i_scrob < scrobbles.length; i_scrob++){
     var delete_button = get_delete_form(scrobbles[i_scrob]);
@@ -32,30 +36,32 @@ var insert_delete_forms = function(){
   }
 }
 
-var scrobblelist = document.getElementsByClassName('tracklist-section')[0];
-
-var addNextListener = function(){
+// adds listeners to a variety of navigation links so as to trigger extension on page change
+var addNextListeners = function(){
   var paginationLinks = document
     .getElementsByClassName("pagination")[0]
     .getElementsByTagName("a");
   for(var i=0; i<paginationLinks.length; i++){
     paginationLinks[i].addEventListener("click", function(){
-      setTimeout(runWhenReady, 3000);
+      setTimeout(waitForNewResults, 1000);
     });
+  }
+}
+
+// checks if injected buttons exist, if yes then components haven't reloaded yet
+var waitForNewResults = function(){
+  var verifier = document.getElementsByClassName('chrome-extension-delete').length;
+  if(verifier !== 0){
+    setTimeout(waitForNewResults, 1000);
+  }
+  else{
+    runWhenReady();
   }
 }
 
 var runWhenReady = function(){
   scrobblelist.ready = insert_delete_forms();
-  setTimeout(addNextListener, 1000);
+  setTimeout(addNextListeners, 1000);
 }
 
 runWhenReady();
-
-
-
-
-// var paginationhack = document.getElementsByClassName('pagination')[0].getElementsByTagName('a');
-// paginationhack[0].addEventListener("click", insert_delete_forms);
-// paginationhack[1].addEventListener("click", insert_delete_forms);
-// this doesn't work but I'm leaving it in as a reminder it needs an alternative

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
 
   "name": "lastfm-delete-track-button",
-  "version": "1.0.1",
-  "description": "Says hello to Google",
+  "version": "1.0.2",
+  "description": "Adds delete buttons on scrobble list",
   "content_scripts": [
     {
       "matches": [


### PR DESCRIPTION
Updated listeners so that they only trigger when the environment has updated (i.e. it can't find any of the new buttons in the dom). This is done using pretty simple timeout operations.

Some other small changes:
- Added icons
- Updated readme to be more readable
- Added CRX file for easier use
- Tried to make code more readable (it's hard when it's so DOM dependent)


There's a pretty good chance I'll just leave this repo as is from here once merged, it's doing everything I needed.